### PR TITLE
feat: add avif format introduced in gatsby v2.30.0

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,9 +32,9 @@ exports.onCreateWebpackConfig = (
     const rules = existingConfig.module.rules.map(rule => {
       if (
         String(rule.test) ===
-        String(/\.(ico|svg|jpg|jpeg|png|gif|webp)(\?.*)?$/)
+        String(/\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/)
       ) {
-        return { ...rule, test: /\.(ico|jpg|jpeg|png|gif|webp)(\?.*)?$/ };
+        return { ...rule, test: /\.(ico|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/ };
       }
 
       return rule;


### PR DESCRIPTION
Gatsby v2.30.0 added AVIF support which means the webpack rule has changed: https://github.com/gatsbyjs/gatsby/blob/121ccbf5feeeffa0a6f87a20fcfc8fd68a71c425/packages/gatsby/src/utils/webpack-utils.ts#L518